### PR TITLE
Fix date macros using date() function

### DIFF
--- a/macros/get_default_end_date.sql
+++ b/macros/get_default_end_date.sql
@@ -7,7 +7,7 @@
 {% if 'current_date()' in end_date %}
     {{ return(end_date) }}
 {% else %}
-    {{ return("date('" + end_date + "')") }}
+    {{ return("'" + end_date + "'") }}
 {% endif %}
 
 {% endmacro %}

--- a/macros/get_default_start_date.sql
+++ b/macros/get_default_start_date.sql
@@ -5,7 +5,7 @@
 {% if 'current_date()' in start_date %}
     {{ return(start_date) }}
 {% else %}
-    {{ return("date('" + start_date + "')") }}
+   {{ return("'" + start_date + "'") }} 
 {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
- Change date(date) to 'date' to support dbs other than BigQuery